### PR TITLE
rust: build, check and test in the docker container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -86,4 +86,5 @@ RUN git clone https://github.com/microsoft/vcpkg \
 
 ENV VCPKG_ROOT="/home/${USERNAME}/vcpkg"
 
-RUN rustup default 1.88.0
+COPY ./scripts/ /tmp/scripts/
+RUN /tmp/scripts/common/rust/install-rust.sh

--- a/.devcontainer/Dockerfile.almalinux
+++ b/.devcontainer/Dockerfile.almalinux
@@ -73,4 +73,5 @@ RUN git clone https://github.com/microsoft/vcpkg \
 
 ENV VCPKG_ROOT=/home/$USERNAME/vcpkg
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.88.0
+COPY ./scripts/ /tmp/scripts/
+RUN /tmp/scripts/common/rust/install-rust.sh

--- a/.devcontainer/Dockerfile.amazonlinux
+++ b/.devcontainer/Dockerfile.amazonlinux
@@ -66,4 +66,5 @@ RUN git clone https://github.com/microsoft/vcpkg \
 
 ENV VCPKG_ROOT=/home/$USERNAME/vcpkg
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.88.0
+COPY ./scripts/ /tmp/scripts/
+RUN /tmp/scripts/common/rust/install-rust.sh

--- a/.devcontainer/Dockerfile.debiantrixie
+++ b/.devcontainer/Dockerfile.debiantrixie
@@ -81,4 +81,5 @@ RUN git clone https://github.com/microsoft/vcpkg \
 
 ENV VCPKG_ROOT="/home/${USERNAME}/vcpkg"
 
-RUN rustup default 1.88.0
+COPY ./scripts/ /tmp/scripts/
+RUN /tmp/scripts/common/rust/install-rust.sh

--- a/.devcontainer/Dockerfile.ubuntu-legacy
+++ b/.devcontainer/Dockerfile.ubuntu-legacy
@@ -100,4 +100,5 @@ ENV VCPKG_ROOT=/home/$USERNAME/vcpkg
 COPY register-clang-version.sh /home/$USERNAME/register-clang-version.sh 
 RUN sudo /home/$USERNAME/register-clang-version.sh ${CLANG_VERSION} 100 && rm /home/$USERNAME/register-clang-version.sh
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=1.88.0
+COPY ./scripts/ /tmp/scripts/
+RUN /tmp/scripts/common/rust/install-rust.sh

--- a/.devcontainer/almalinux/devcontainer.json
+++ b/.devcontainer/almalinux/devcontainer.json
@@ -28,7 +28,8 @@
                 "matepek.vscode-catch2-test-adapter",
                 "llvm-vs-code-extensions.vscode-clangd",
                 "xaver.clang-format",
-                "bierner.markdown-mermaid"
+                "bierner.markdown-mermaid",
+                "rust-lang.rust-analyzer"
             ],
             "settings": {
                 "C_Cpp.intelliSenseEngine": "disabled",

--- a/.devcontainer/amazonlinux/devcontainer.json
+++ b/.devcontainer/amazonlinux/devcontainer.json
@@ -32,7 +32,8 @@
                 "matepek.vscode-catch2-test-adapter",
                 "llvm-vs-code-extensions.vscode-clangd",
                 "xaver.clang-format",
-                "bierner.markdown-mermaid"
+                "bierner.markdown-mermaid",
+                "rust-lang.rust-analyzer"
             ],
             "settings": {
                 "C_Cpp.intelliSenseEngine": "disabled",

--- a/.devcontainer/debiantrixie/devcontainer.json
+++ b/.devcontainer/debiantrixie/devcontainer.json
@@ -28,7 +28,8 @@
                 "matepek.vscode-catch2-test-adapter",
                 "llvm-vs-code-extensions.vscode-clangd",
                 "xaver.clang-format",
-                "bierner.markdown-mermaid"
+                "bierner.markdown-mermaid",
+                "rust-lang.rust-analyzer"
             ],
             "settings": {
                 "C_Cpp.intelliSenseEngine": "disabled",

--- a/.devcontainer/scripts/common/rust/install-rust.sh
+++ b/.devcontainer/scripts/common/rust/install-rust.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: Apache-2.0
+
+set -eu
+
+RUST_VERSION=1.88.0
+
+if command -v rustup >/dev/null 2>&1; then
+    rustup default $RUST_VERSION
+else
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=$RUST_VERSION
+    . "$HOME/.cargo/env"
+fi
+
+# Install cargo binstall
+curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
+cargo binstall cargo-audit --locked
+cargo binstall cargo-outdated --locked
+
+# udeps requires the nightly compiler, so using machete (at least for now)
+# cargo binstall cargo-udeps --locked
+cargo binstall cargo-machete --locked
+
+cargo binstall cargo-deny --locked
+cargo binstall cargo-audit --locked
+cargo binstall cargo-nextest --locked

--- a/.devcontainer/scripts/common/rust/install-rust.sh
+++ b/.devcontainer/scripts/common/rust/install-rust.sh
@@ -5,9 +5,9 @@
 
 set -eu
 
-RUST_VERSION=1.88.0
+RUST_VERSION=1.90.0
 
-if command -v rustup >/dev/null 2>&1; then
+if command -v rustup > /dev/null 2>&1; then
     rustup default $RUST_VERSION
 else
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain=$RUST_VERSION

--- a/.devcontainer/ubuntu20/devcontainer.json
+++ b/.devcontainer/ubuntu20/devcontainer.json
@@ -30,7 +30,8 @@
                 "matepek.vscode-catch2-test-adapter",
                 "llvm-vs-code-extensions.vscode-clangd",
                 "xaver.clang-format",
-                "bierner.markdown-mermaid"
+                "bierner.markdown-mermaid",
+                "rust-lang.rust-analyzer"
             ],
             "settings": {
                 "C_Cpp.intelliSenseEngine": "disabled",

--- a/.devcontainer/ubuntu22/devcontainer.json
+++ b/.devcontainer/ubuntu22/devcontainer.json
@@ -30,7 +30,8 @@
                 "matepek.vscode-catch2-test-adapter",
                 "llvm-vs-code-extensions.vscode-clangd",
                 "xaver.clang-format",
-                "bierner.markdown-mermaid"
+                "bierner.markdown-mermaid",
+                "rust-lang.rust-analyzer"
             ],
             "settings": {
                 "C_Cpp.intelliSenseEngine": "disabled",

--- a/.devcontainer/ubuntu24/devcontainer.json
+++ b/.devcontainer/ubuntu24/devcontainer.json
@@ -30,7 +30,8 @@
                 "matepek.vscode-catch2-test-adapter",
                 "llvm-vs-code-extensions.vscode-clangd",
                 "xaver.clang-format",
-                "bierner.markdown-mermaid"
+                "bierner.markdown-mermaid",
+                "rust-lang.rust-analyzer"
             ],
             "settings": {
                 "C_Cpp.intelliSenseEngine": "disabled",

--- a/.devcontainer/ubuntu25/devcontainer.json
+++ b/.devcontainer/ubuntu25/devcontainer.json
@@ -30,7 +30,8 @@
                 "matepek.vscode-catch2-test-adapter",
                 "llvm-vs-code-extensions.vscode-clangd",
                 "xaver.clang-format",
-                "bierner.markdown-mermaid"
+                "bierner.markdown-mermaid",
+                "rust-lang.rust-analyzer"
             ],
             "settings": {
                 "C_Cpp.intelliSenseEngine": "disabled",

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: Apache-2.0
+
 name: Test the rust bindings
 
 on:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ else()
     string(APPEND mxl_VERSION ".0")
 endif()
 
+option(BUILD_DOCS "Build the docs" ON)
 option(BUILD_TESTS "Build the tests" ON)
 option(BUILD_TOOLS "Build the tools" ON)
 
@@ -62,39 +63,41 @@ if (BUILD_TOOLS)
     add_subdirectory(tools)
 endif()
 
-find_package(Doxygen)
+if(BUILD_DOCS)
+    find_package(Doxygen)
 
-if(DOXYGEN_FOUND)
-    include(FetchContent)
+    if(DOXYGEN_FOUND)
+        include(FetchContent)
 
-    FetchContent_Declare(
-        doxygen-awesome-css
-        URL https://github.com/jothepro/doxygen-awesome-css/archive/refs/heads/main.zip
-    )
-    FetchContent_MakeAvailable(doxygen-awesome-css)
+        FetchContent_Declare(
+            doxygen-awesome-css
+            URL https://github.com/jothepro/doxygen-awesome-css/archive/refs/heads/main.zip
+        )
+        FetchContent_MakeAvailable(doxygen-awesome-css)
 
-    # Save the location the files were cloned into
-    # This allows us to get the path to doxygen-awesome.css
-    FetchContent_GetProperties(doxygen-awesome-css SOURCE_DIR AWESOME_CSS_DIR)
+        # Save the location the files were cloned into
+        # This allows us to get the path to doxygen-awesome.css
+        FetchContent_GetProperties(doxygen-awesome-css SOURCE_DIR AWESOME_CSS_DIR)
 
-    # Generate the Doxyfile
-    set(DOXYFILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
-    set(DOXYFILE_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
-    configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
+        # Generate the Doxyfile
+        set(DOXYFILE_IN ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in)
+        set(DOXYFILE_OUT ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile)
+        configure_file(${DOXYFILE_IN} ${DOXYFILE_OUT} @ONLY)
 
-    set(DOXYGEN_OUTPUT_DIR "${CMAKE_BINARY_DIR}/docs")
+        set(DOXYGEN_OUTPUT_DIR "${CMAKE_BINARY_DIR}/docs")
 
-    add_custom_target(doc
-        COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_OUT}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-        COMMENT "Generating API documentation with Doxygen"
-        BYPRODUCTS "${DOXYGEN_OUTPUT_DIR}/html/index.html"
-        VERBATIM
-    )
+        add_custom_target(doc
+            COMMAND ${DOXYGEN_EXECUTABLE} ${DOXYFILE_OUT}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+            COMMENT "Generating API documentation with Doxygen"
+            BYPRODUCTS "${DOXYGEN_OUTPUT_DIR}/html/index.html"
+            VERBATIM
+        )
 
-    install(DIRECTORY "${CMAKE_BINARY_DIR}/docs/html"
-        DESTINATION share/doc/mxl
-        FILES_MATCHING PATTERN "*")
+        install(DIRECTORY "${CMAKE_BINARY_DIR}/docs/html"
+            DESTINATION share/doc/mxl
+            FILES_MATCHING PATTERN "*")
+    endif()
 endif()
 
 if(EXISTS "/etc/os-release")

--- a/rust/.config/nextest.toml
+++ b/rust/.config/nextest.toml
@@ -1,0 +1,5 @@
+[profile.ci]
+fail-fast = false
+
+[profile.ci.junit]
+path = "junit.xml"

--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: Apache-2.0
+
 .DS_Store
 .idea
 .vscode

--- a/rust/Cargo.lock.license
+++ b/rust/Cargo.lock.license
@@ -1,4 +1,2 @@
 # SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
 # SPDX-License-Identifier: Apache-2.0
-
-Cargo.lock -diff

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: Apache-2.0
+
 [workspace]
 members = ["mxl", "mxl-sys"]
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Rust bindings for DMF MXL
 
 ## Goals

--- a/rust/flake.nix
+++ b/rust/flake.nix
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: Apache-2.0
+
 {
   description = "Flake for MXL dev";
 

--- a/rust/mxl-sys/.gitignore
+++ b/rust/mxl-sys/.gitignore
@@ -1,1 +1,4 @@
+# SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: Apache-2.0
+
 mxl/version.h

--- a/rust/mxl-sys/Cargo.toml
+++ b/rust/mxl-sys/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "mxl-sys"
 edition.workspace = true

--- a/rust/mxl-sys/build.rs
+++ b/rust/mxl-sys/build.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::env;
 use std::path::PathBuf;
 

--- a/rust/mxl-sys/build.rs
+++ b/rust/mxl-sys/build.rs
@@ -48,13 +48,19 @@ fn get_bindgen_specs() -> BindgenSpecs {
         let mxl_version_header = mxl_version_out_path.join("version.h");
         println!("cargo:rerun-if-changed={}", mxl_version_header.display());
         // TODO: re-run on build_dir changing?
+        // TODO: re-run on any changes in lib
+
+        let out_dir = PathBuf::from(std::env::var("OUT_DIR").unwrap());
 
         let dst = cmake::Config::new(repo_root)
-            .out_dir(build_dir)
-            .generator("Unix Makefiles")
+            .generator("Ninja")
+            .configure_arg("--preset")
+            .configure_arg(BUILD_VARIANT)
+            .configure_arg("-B")
+            .configure_arg(out_dir.join("build"))
+            .define("BUILD_DOCS", "OFF")
             .define("BUILD_TESTS", "OFF")
             .define("BUILD_TOOLS", "OFF")
-            // .configure_arg(format!("--preset={BUILD_VARIANT}"))
             .build();
 
         let mxl_version_location = dst.join("include").join("mxl").join("version.h");

--- a/rust/mxl-sys/src/lib.rs
+++ b/rust/mxl-sys/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]

--- a/rust/mxl-sys/src/lib.rs
+++ b/rust/mxl-sys/src/lib.rs
@@ -2,6 +2,8 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 #![allow(missing_docs)]
+#![allow(rustdoc::broken_intra_doc_links)]
+#![allow(rustdoc::invalid_html_tags)]
 // Suppress expected warnings from bindgen-generated code.
 // See https://github.com/rust-lang/rust-bindgen/issues/1651.
 #![allow(deref_nullptr)]

--- a/rust/mxl-sys/tests/simple_test.rs
+++ b/rust/mxl-sys/tests/simple_test.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 #[test]
 fn there_is_bindgen_generated_code() {
     let mxl_version = mxl_sys::mxlVersionType {

--- a/rust/mxl-sys/wrapper-with-version-h.h
+++ b/rust/mxl-sys/wrapper-with-version-h.h
@@ -1,2 +1,5 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "wrapper-without-version-h.h"
 #include "mxl/version.h"

--- a/rust/mxl-sys/wrapper-without-version-h.h
+++ b/rust/mxl-sys/wrapper-without-version-h.h
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 #include "mxl/dataformat.h"
 #include "mxl/flow.h"
 #include "mxl/flowinfo.h"

--- a/rust/mxl/Cargo.toml
+++ b/rust/mxl/Cargo.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+# SPDX-License-Identifier: Apache-2.0
+
 [package]
 name = "mxl"
 edition.workspace = true

--- a/rust/mxl/build.rs
+++ b/rust/mxl/build.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::env;
 use std::path::PathBuf;
 

--- a/rust/mxl/examples/common/mod.rs
+++ b/rust/mxl/examples/common/mod.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 pub fn setup_logging() {
     tracing_subscriber::fmt()
         .with_env_filter(

--- a/rust/mxl/examples/flow-reader.rs
+++ b/rust/mxl/examples/flow-reader.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 mod common;
 
 use std::time::Duration;

--- a/rust/mxl/examples/flow-reader.rs
+++ b/rust/mxl/examples/flow-reader.rs
@@ -3,7 +3,7 @@ mod common;
 use std::time::Duration;
 
 use clap::Parser;
-use mxl::config::get_mxf_so_path;
+use mxl::config::get_mxl_so_path;
 use tracing::{info, warn};
 
 const READ_TIMEOUT: Duration = Duration::from_secs(5);
@@ -30,7 +30,7 @@ fn main() -> Result<(), mxl::Error> {
     common::setup_logging();
     let opts: Opts = Opts::parse();
 
-    let mxl_api = mxl::load_api(get_mxf_so_path())?;
+    let mxl_api = mxl::load_api(get_mxl_so_path())?;
     let mxl_instance = mxl::MxlInstance::new(mxl_api, &opts.mxl_domain, "")?;
     let reader = mxl_instance.create_flow_reader(&opts.flow_id)?;
     let flow_info = reader.get_info()?;

--- a/rust/mxl/examples/flow-writer.rs
+++ b/rust/mxl/examples/flow-writer.rs
@@ -3,7 +3,7 @@ mod common;
 use clap::Parser;
 use tracing::info;
 
-use mxl::config::get_mxf_so_path;
+use mxl::config::get_mxl_so_path;
 
 #[derive(Debug, Parser)]
 #[command(version = clap::crate_version!(), author = clap::crate_authors!())]
@@ -30,7 +30,7 @@ fn main() -> Result<(), mxl::Error> {
     common::setup_logging();
     let opts: Opts = Opts::parse();
 
-    let mxl_api = mxl::load_api(get_mxf_so_path())?;
+    let mxl_api = mxl::load_api(get_mxl_so_path())?;
     let mxl_instance = mxl::MxlInstance::new(mxl_api, &opts.mxl_domain, "")?;
     let flow_def = mxl::tools::read_file(opts.flow_config_file.as_str()).map_err(|error| {
         mxl::Error::Other(format!(

--- a/rust/mxl/examples/flow-writer.rs
+++ b/rust/mxl/examples/flow-writer.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 mod common;
 
 use clap::Parser;

--- a/rust/mxl/src/api.rs
+++ b/rust/mxl/src/api.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::path::Path;
 
 use dlopen2::wrapper::{Container, WrapperApi};

--- a/rust/mxl/src/config.rs
+++ b/rust/mxl/src/config.rs
@@ -3,10 +3,9 @@ use std::str::FromStr;
 include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 
 pub fn get_mxf_so_path() -> std::path::PathBuf {
-    std::path::PathBuf::from_str(MXL_BUILD_DIR)
-        .expect("build error: 'MXL_BUILD_DIR' is invalid")
-        .join("lib")
-        .join("libmxl.so")
+    // The mxl-sys build script ensures that the build directory is in the library path
+    // so we can just return the library name here.
+    "libmxl.so".into()
 }
 
 pub fn get_mxl_repo_root() -> std::path::PathBuf {

--- a/rust/mxl/src/config.rs
+++ b/rust/mxl/src/config.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::str::FromStr;
 
 include!(concat!(env!("OUT_DIR"), "/constants.rs"));

--- a/rust/mxl/src/config.rs
+++ b/rust/mxl/src/config.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 include!(concat!(env!("OUT_DIR"), "/constants.rs"));
 
-pub fn get_mxf_so_path() -> std::path::PathBuf {
+pub fn get_mxl_so_path() -> std::path::PathBuf {
     // The mxl-sys build script ensures that the build directory is in the library path
     // so we can just return the library name here.
     "libmxl.so".into()

--- a/rust/mxl/src/error.rs
+++ b/rust/mxl/src/error.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 pub type Result<T> = core::result::Result<T, Error>;
 
 #[derive(Debug, thiserror::Error)]

--- a/rust/mxl/src/flow.rs
+++ b/rust/mxl/src/flow.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod reader;
 pub mod writer;
 

--- a/rust/mxl/src/flow/reader.rs
+++ b/rust/mxl/src/flow/reader.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 
 use crate::{

--- a/rust/mxl/src/flow/writer.rs
+++ b/rust/mxl/src/flow/writer.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 
 use crate::{

--- a/rust/mxl/src/grain.rs
+++ b/rust/mxl/src/grain.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod data;
 pub mod reader;
 pub mod write_access;

--- a/rust/mxl/src/grain/data.rs
+++ b/rust/mxl/src/grain/data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 pub struct GrainData<'a> {
     pub user_data: &'a [u8],
     pub payload: &'a [u8],

--- a/rust/mxl/src/grain/reader.rs
+++ b/rust/mxl/src/grain/reader.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{sync::Arc, time::Duration};
 
 use crate::{

--- a/rust/mxl/src/grain/write_access.rs
+++ b/rust/mxl/src/grain/write_access.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{marker::PhantomData, sync::Arc};
 
 use tracing::error;

--- a/rust/mxl/src/grain/writer.rs
+++ b/rust/mxl/src/grain/writer.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 
 use super::write_access::GrainWriteAccess;

--- a/rust/mxl/src/instance.rs
+++ b/rust/mxl/src/instance.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{ffi::CString, sync::Arc};
 
 use dlopen2::wrapper::Container;

--- a/rust/mxl/src/lib.rs
+++ b/rust/mxl/src/lib.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 mod api;
 mod error;
 mod flow;

--- a/rust/mxl/src/samples.rs
+++ b/rust/mxl/src/samples.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 pub mod data;
 pub mod reader;
 pub mod write_access;

--- a/rust/mxl/src/samples/data.rs
+++ b/rust/mxl/src/samples/data.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::marker::PhantomData;
 
 use crate::Error;

--- a/rust/mxl/src/samples/reader.rs
+++ b/rust/mxl/src/samples/reader.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 
 use crate::{

--- a/rust/mxl/src/samples/write_access.rs
+++ b/rust/mxl/src/samples/write_access.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::{marker::PhantomData, sync::Arc};
 
 use tracing::error;

--- a/rust/mxl/src/samples/writer.rs
+++ b/rust/mxl/src/samples/writer.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 use std::sync::Arc;
 
 use crate::{Error, Result, SamplesWriteAccess, instance::InstanceContext};

--- a/rust/mxl/src/tools.rs
+++ b/rust/mxl/src/tools.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 pub fn read_file(file_path: impl AsRef<std::path::Path>) -> Result<String, std::io::Error> {
     use std::io::Read;
 

--- a/rust/mxl/tests/basic_tests.rs
+++ b/rust/mxl/tests/basic_tests.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: 2025 2025 Contributors to the Media eXchange Layer project.
+// SPDX-License-Identifier: Apache-2.0
+
 /// Tests of the basic low level synchronous API.
 ///
 /// The tests now require an MXL library of a specific name to be present in the system. This should

--- a/rust/mxl/tests/basic_tests.rs
+++ b/rust/mxl/tests/basic_tests.rs
@@ -4,7 +4,7 @@
 /// change in the future. For now, feel free to just edit the path to your library.
 use std::time::Duration;
 
-use mxl::{MxlInstance, OwnedGrainData, OwnedSamplesData, config::get_mxf_so_path};
+use mxl::{MxlInstance, OwnedGrainData, OwnedSamplesData, config::get_mxl_so_path};
 use tracing::info;
 
 static LOG_ONCE: std::sync::Once = std::sync::Once::new();
@@ -32,7 +32,7 @@ fn setup_test(test: &str) -> mxl::MxlInstance {
             .init();
     });
 
-    let mxl_api = mxl::load_api(get_mxf_so_path()).unwrap();
+    let mxl_api = mxl::load_api(get_mxl_so_path()).unwrap();
     let domain = setup_empty_domain(test);
     mxl::MxlInstance::new(mxl_api, &domain, "").unwrap()
 }


### PR DESCRIPTION
- updates the Dockerfiles so that all the tools needed for building, checking and testing the Rust bindings are included
  - including nextest, so that we can generate test reports compatible with the C++ ones.
- adjusts the build system so that libmxl is built in Rust's target directory
  - uses the CMake presets appropriately, to match the settings used in CMake.